### PR TITLE
Set rust toolchain to nightly by default

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,0 +1,1 @@
+nightly


### PR DESCRIPTION
This way we don't have to put `+nightly` on all invocations of `cargo`.