### PR TITLE
Added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# General settings.
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Exceptions follow beneath:
+
+[*.rs]
+indent_size = 4


### PR DESCRIPTION
This way we can get more consistent space indents and stuff:

- Indent style is 2 spaces but 4 spaces for Rust files (`*.rs`)
- EOL is LF
- UTF-8 charset
- Inserting newline at EOF
- ~Don't trim trailing whitespace because it can be very annoying when saving often while editing~ trims trailing whitespace