### PR TITLE
Align test output wrt max test name lengths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 #![reexport_test_harness_main = "test_main"]
 
 mod qemu;
+
 #[cfg(test)]
 use crate::qemu::{exit_qemu, QemuExitCode};
 
@@ -17,6 +18,7 @@ mod util;
 
 #[macro_use]
 mod serial;
+
 #[cfg(test)]
 mod test;
 

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,23 +1,47 @@
 use crate::qemu::{exit_qemu, QemuExitCode};
 
 pub fn test_runner(tests: &[&dyn Testable]) {
-    serial_println!("Running {} tests", tests.len());
-    for test in tests {
-        test.run();
+    let amount = tests.len();
+    serial_println!("Running {} tests", amount);
+    if amount > 0 {
+        let max_name_len = tests
+            .iter()
+            .max_by_key(|x| x.name_len())
+            .unwrap()
+            .name_len();
+        for test in tests {
+            test.run(max_name_len);
+        }
     }
     exit_qemu(QemuExitCode::Success)
 }
 
 pub trait Testable {
-    fn run(&self);
+    fn name(&self) -> &'static str;
+    fn name_len(&self) -> usize;
+    fn run(&self, max_name_len: usize);
 }
 
 impl<T> Testable for T
 where
     T: Fn(),
 {
-    fn run(&self) {
-        serial_print!("{}...\t", core::any::type_name::<T>());
+    fn name(&self) -> &'static str {
+        core::any::type_name::<T>()
+    }
+
+    fn name_len(&self) -> usize {
+        self.name().len()
+    }
+
+    fn run(&self, max_name_len: usize) {
+        let name = self.name();
+        serial_print!(
+            "{}..{:>width$}",
+            name,
+            "",
+            width = max_name_len - name.len() + 1
+        );
         self();
         serial_println!("[ok]")
     }


### PR DESCRIPTION
With this change, we get aligned "[ok]" on the rigth:
```
ferocios::vga::color::Color_entries_amount..        [ok]
ferocios::vga::color::Color_number..                [ok]
ferocios::vga::color::Color_from..                  [ok]
ferocios::vga::color::ColorCode_foreground..        [ok]
ferocios::vga::color::ColorCode_background..        [ok]
ferocios::vga::color_scoped_writer::color_code..    [ok]
ferocios::vga::color_scoped_writer::reset_on_drop.. [ok]
ferocios::vga::writer::set_color_code..             [ok]
ferocios::vga::writer::retain_previous_color..      [ok]
ferocios::vga::writer::reset_color_code..           [ok]
ferocios::vga::writer::color_scope..                [ok]
```