### PR TITLE
Output x/y test progress

### DIFF
--- a/src/test.rs
+++ b/src/test.rs
@@ -1,4 +1,5 @@
 use crate::qemu::{exit_qemu, QemuExitCode};
+use crate::util::digit_width;
 
 pub fn test_runner(tests: &[&dyn Testable]) {
     let amount = tests.len();
@@ -9,8 +10,11 @@ pub fn test_runner(tests: &[&dyn Testable]) {
             .max_by_key(|x| x.name_len())
             .unwrap()
             .name_len();
+
+        let mut num = 0;
         for test in tests {
-            test.run(max_name_len);
+            test.run(num, amount, max_name_len);
+            num += 1;
         }
     }
     exit_qemu(QemuExitCode::Success)
@@ -19,7 +23,7 @@ pub fn test_runner(tests: &[&dyn Testable]) {
 pub trait Testable {
     fn name(&self) -> &'static str;
     fn name_len(&self) -> usize;
-    fn run(&self, max_name_len: usize);
+    fn run(&self, test_num: usize, test_amount: usize, max_name_len: usize);
 }
 
 impl<T> Testable for T
@@ -34,10 +38,16 @@ where
         self.name().len()
     }
 
-    fn run(&self, max_name_len: usize) {
+    fn run(&self, test_num: usize, test_amount: usize, max_name_len: usize) {
         let name = self.name();
         serial_print!(
-            "{}..{:>width$}",
+            "[{}] {}..{:>width$}",
+            format_args!(
+                "{:width$}/{:width$}",
+                test_num + 1,
+                test_amount,
+                width = digit_width(test_amount)
+            ),
             name,
             "",
             width = max_name_len - name.len() + 1

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+use core::cmp;
+
 /// This macro returns the name of the enclosing function.
 ///
 /// It is ported from stdext::function_name to work without std.
@@ -12,4 +14,28 @@ macro_rules! function_name {
         let name = type_name_of(f);
         &name[..name.len() - 3] // `3` is the length of the `::f`.
     }};
+}
+
+/// Calculate the digit width of a number, like 100 = 3.
+///
+/// This function is necessary since we can't use f32.log32() that is part of std, and we can't
+/// easily use intrinsics either.
+#[allow(dead_code)]
+pub fn digit_width(n: usize) -> usize {
+    let mut digits = 0;
+    let mut m = n;
+    while m > 0 {
+        m /= 10;
+        digits += 1
+    }
+    cmp::max(1, digits)
+}
+
+#[test_case]
+fn digit_width() {
+    assert_eq!(1, digit_width(0));
+    assert_eq!(1, digit_width(1));
+    assert_eq!(2, digit_width(10));
+    assert_eq!(3, digit_width(100));
+    assert_eq!(4, digit_width(1000));
 }


### PR DESCRIPTION
Now it looks like:
```
[ 1/12] ferocios::util::digit_width..                       [ok]
[ 2/12] ferocios::vga::color::Color_entries_amount..        [ok]
[ 3/12] ferocios::vga::color::Color_number..                [ok]
[ 4/12] ferocios::vga::color::Color_from..                  [ok]
[ 5/12] ferocios::vga::color::ColorCode_foreground..        [ok]
[ 6/12] ferocios::vga::color::ColorCode_background..        [ok]
[ 7/12] ferocios::vga::color_scoped_writer::color_code..    [ok]
[ 8/12] ferocios::vga::color_scoped_writer::reset_on_drop.. [ok]
[ 9/12] ferocios::vga::writer::set_color_code..             [ok]
[10/12] ferocios::vga::writer::retain_previous_color..      [ok]
[11/12] ferocios::vga::writer::reset_color_code..           [ok]
[12/12] ferocios::vga::writer::color_scope..                [ok]
```