### PR TITLE
[audit] Use spinning instead of spin because it's unmaintained

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,7 +46,7 @@ dependencies = [
  "enum-iterator",
  "lazy_static",
  "rlibc",
- "spin",
+ "spinning",
  "uart_16550",
  "volatile",
  "x86_64",
@@ -59,6 +59,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
  "spin",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28247cc5a5be2f05fbcd76dd0cf2c7d3b5400cb978a28042abcd4fa0b3f8261c"
+dependencies = [
+ "scopeguard",
 ]
 
 [[package]]
@@ -86,10 +95,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc874b127765f014d792f16763a81245ab80500e2ad921ed4ee9e82481ee08fe"
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spinning"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced8156fe289bee8576050d3924fe6f3926b552b41afe810f5461acaca42c9f1"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,13 @@ edition = "2018"
 rlibc = "1.0.0"
 bootloader = "0.9.8"
 volatile = "0.3.0"
-spin = "0.5.2"
 x86_64 = "0.11.0"
 uart_16550 = "0.2.0"
 enum-iterator = "0.6.0"
+
+[dependencies.spinning]
+version = "0.0.3"
+default-features = false
 
 [dependencies.lazy_static]
 version = "1.0"

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -1,5 +1,5 @@
 use lazy_static::lazy_static;
-use spin::Mutex;
+use spinning::Mutex;
 use uart_16550::SerialPort;
 
 lazy_static! {

--- a/src/vga/writer.rs
+++ b/src/vga/writer.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 use lazy_static::lazy_static;
-use spin::Mutex;
+use spinning::Mutex;
 use volatile::Volatile;
 
 use super::color::{Color, ColorCode};


### PR DESCRIPTION
`lazy_static` still depends on spin but at least now we don't.

```
Crate:  spin
Title:  spin is no longer actively maintained
Date:   2019-11-21
URL:    https://rustsec.org/advisories/RUSTSEC-2019-0031
Dependency tree:
spin 0.5.2
├── lazy_static 1.4.0
│   └── ferocios 0.1.0
└── ferocios 0.1.0
```