### PR TITLE
Add GDT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bootloader"
-version = "0.9.8"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad686b9b47363de7d36c05fb6885f17d08d0f2d15b1bc782a101fe3c94a2c7c"
+checksum = "83732ad599045a978528e4311539fdcb20c30e406b66d1d08cd4089d4fc8d90f"
 
 [[package]]
 name = "enum-iterator"
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "uart_16550"
-version = "0.2.7"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58fc40dc1712664fc9b0a7bd8ca2f21ab49960924fb245a80a05e1e92f3dfe9"
+checksum = "afb00b16a4c8acbfc4eb8cfeda1f9c0507c7e87c6563edce64a236af93acf70c"
 dependencies = [
  "bitflags",
  "x86_64",
@@ -150,9 +150,9 @@ checksum = "f8e76fae08f03f96e166d2dfda232190638c10e0383841252416f9cfe2ae60e6"
 
 [[package]]
 name = "x86_64"
-version = "0.11.5"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c6e9604d08cf91ba0e5cc2175e8cbbdeeb2b8230b818fd9052604c4c5ffd620"
+checksum = "d5b4b42dbabe13b69023e1a1407d395f1a1a33df76e9a9efdbe303acc907e292"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 
 [dependencies]
 rlibc = "1.0.0"
-bootloader = "0.9.8"
+bootloader = "0.9.11"
 volatile = "0.3.0"
-x86_64 = "0.11.0"
-uart_16550 = "0.2.0"
+x86_64 = "0.12.2"
+uart_16550 = "0.2.10"
 enum-iterator = "0.6.0"
 
 [dependencies.spinning]

--- a/src/gdt.rs
+++ b/src/gdt.rs
@@ -1,0 +1,49 @@
+use lazy_static::lazy_static;
+use x86_64::instructions::segmentation::set_cs;
+use x86_64::instructions::tables::load_tss;
+use x86_64::structures::gdt::{Descriptor, GlobalDescriptorTable, SegmentSelector};
+use x86_64::{structures::tss::TaskStateSegment, VirtAddr};
+
+pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
+
+pub fn init() {
+    GDT.gdt.load();
+    unsafe {
+        set_cs(GDT.code_selector);
+        load_tss(GDT.tss_selector)
+    }
+}
+
+lazy_static! {
+    static ref TSS: TaskStateSegment = {
+        let mut tss = TaskStateSegment::new();
+        tss.interrupt_stack_table[DOUBLE_FAULT_IST_INDEX as usize] = {
+            const STACK_SIZE: usize = 4096 * 5;
+            static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
+
+            let stack_start = VirtAddr::from_ptr(unsafe { &STACK });
+            stack_start + STACK_SIZE
+        };
+        tss
+    };
+}
+
+lazy_static! {
+    static ref GDT: GdtLayout = {
+        let mut gdt = GlobalDescriptorTable::new();
+        let code_selector = gdt.add_entry(Descriptor::kernel_code_segment());
+        let tss_selector = gdt.add_entry(Descriptor::tss_segment(&TSS));
+
+        GdtLayout {
+            gdt,
+            code_selector,
+            tss_selector,
+        }
+    };
+}
+
+struct GdtLayout {
+    gdt: GlobalDescriptorTable,
+    code_selector: SegmentSelector,
+    tss_selector: SegmentSelector,
+}

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -1,6 +1,8 @@
 use lazy_static::lazy_static;
 use x86_64::structures::idt::{InterruptDescriptorTable, InterruptStackFrame, PageFaultErrorCode};
 
+use crate::gdt;
+
 lazy_static! {
     static ref IDT: InterruptDescriptorTable = {
         let mut idt = InterruptDescriptorTable::new();
@@ -16,7 +18,11 @@ lazy_static! {
         idt.invalid_opcode.set_handler_fn(invalid_opcode_handler);
         idt.device_not_available
             .set_handler_fn(device_not_available_handler);
-        idt.double_fault.set_handler_fn(double_fault_handler);
+
+        unsafe {
+            idt.double_fault.set_handler_fn(double_fault_handler).set_stack_index(gdt::DOUBLE_FAULT_IST_INDEX)
+        };
+
         idt.invalid_tss.set_handler_fn(invalid_tss_handler);
         idt.segment_not_present
             .set_handler_fn(segment_not_present_handler);

--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -46,7 +46,7 @@ lazy_static! {
     };
 }
 
-pub fn init_idt() {
+pub fn init() {
     IDT.load()
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ fn panic(info: &PanicInfo) -> ! {
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
     gdt::init();
-    interrupts::init_idt();
+    interrupts::init();
     println!("FerociOS booting..");
 
     #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ mod test;
 #[macro_use]
 mod vga;
 
+mod gdt;
 mod interrupts;
 
 #[cfg(not(test))]
@@ -49,6 +50,7 @@ fn panic(info: &PanicInfo) -> ! {
 
 #[no_mangle]
 pub extern "C" fn _start() -> ! {
+    gdt::init();
     interrupts::init_idt();
     println!("FerociOS booting..");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,14 +48,18 @@ fn panic(info: &PanicInfo) -> ! {
     loop {}
 }
 
-#[no_mangle]
-pub extern "C" fn _start() -> ! {
+fn init() {
     gdt::init();
     interrupts::init();
-    println!("FerociOS booting..");
 
     #[cfg(test)]
     test_main();
+}
 
+#[no_mangle]
+pub extern "C" fn _start() -> ! {
+    init();
+
+    println!("FerociOS booting..");
     panic!("Not implemented")
 }


### PR DESCRIPTION
Based from https://github.com/ferocios/ferocios/pull/17.

Adds Global Descriptor Table to be used with the double fault handler to switch to a new stack frame.