### PR TITLE
Update deps to work with rust 1.49.0-nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,9 +14,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bootloader"
-version = "0.9.8"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad686b9b47363de7d36c05fb6885f17d08d0f2d15b1bc782a101fe3c94a2c7c"
+checksum = "83732ad599045a978528e4311539fdcb20c30e406b66d1d08cd4089d4fc8d90f"
 
 [[package]]
 name = "enum-iterator"
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "uart_16550"
-version = "0.2.7"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e58fc40dc1712664fc9b0a7bd8ca2f21ab49960924fb245a80a05e1e92f3dfe9"
+checksum = "afb00b16a4c8acbfc4eb8cfeda1f9c0507c7e87c6563edce64a236af93acf70c"
 dependencies = [
  "bitflags",
  "x86_64",
@@ -150,9 +150,9 @@ checksum = "f8e76fae08f03f96e166d2dfda232190638c10e0383841252416f9cfe2ae60e6"
 
 [[package]]
 name = "x86_64"
-version = "0.11.5"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c6e9604d08cf91ba0e5cc2175e8cbbdeeb2b8230b818fd9052604c4c5ffd620"
+checksum = "d5b4b42dbabe13b69023e1a1407d395f1a1a33df76e9a9efdbe303acc907e292"
 dependencies = [
  "bit_field",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2018"
 
 [dependencies]
 rlibc = "1.0.0"
-bootloader = "0.9.8"
+bootloader = "0.9.11"
 volatile = "0.3.0"
-x86_64 = "0.11.0"
-uart_16550 = "0.2.0"
+x86_64 = "0.12.2"
+uart_16550 = "0.2.10"
 enum-iterator = "0.6.0"
 
 [dependencies.spinning]


### PR DESCRIPTION
The CI machine downloads the latest version of rust nightly (currently `rustc 1.49.0-nightly (b1af43bc6 2020-10-10)`) and some packages are failing with functionality that is behind features flags now. The specific error messages can be seen [here](https://github.com/ferocios/ferocios/runs/1239595161?check_suite_focus=true).

Updated packages:
```
bootloader = 0.9.11
x86_64 = 0.12.2
uart_16550 = 0.2.10
```