### PR TITLE
[clippy] Ensure assertion on constant isn't optimized out

### DIFF
--- a/src/interrupts.rs
+++ b/src/interrupts.rs
@@ -205,7 +205,9 @@ fn test_divide_by_zero() {
         asm!("mov dx, 0");
         asm!("div dx")
     }
-    // The exception handler will progress the instruction_pointer to this
-    // instruction so the test will pass.
-    assert!(true)
+    // The exception handler will progress the instruction_pointer to this instruction so the test
+    // will pass. The value is put into a variable because `assert!(true)` could be optimized out by
+    // the compiler.
+    let res = true;
+    assert!(res)
 }


### PR DESCRIPTION
The warning was:
```
warning: `assert!(true)` will be optimized out by the compiler
   --> src/interrupts.rs:213:5
    |
213 |     assert!(true);
    |     ^^^^^^^^^^^^^^
    |
    = note: `#[warn(clippy::assertions_on_constants)]` on by default
    = help: remove it
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#assertions_on_constants
    = note: this warning originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```